### PR TITLE
Read proper Template environment variable when running a simulation.

### DIFF
--- a/src/IotTelemetrySimulator/RunnerConfiguration.cs
+++ b/src/IotTelemetrySimulator/RunnerConfiguration.cs
@@ -112,7 +112,7 @@
 
             var isDefaultTemplateContent = false;
             TelemetryTemplate defaultPayloadTemplate = null;
-            var rawTelemetryTemplate = configuration.GetValue<string>(nameof(Constants.TemplateConfigName));
+            var rawTelemetryTemplate = configuration.GetValue<string>(Constants.TemplateConfigName);
             if (!string.IsNullOrWhiteSpace(rawTelemetryTemplate))
             {
                 defaultPayloadTemplate = new TelemetryTemplate(rawTelemetryTemplate);


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This is a fix to the "Template" environment variable being ignored by the IoT Telemetry Simulator.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
*  Run a telemetry simulation with a custom "Template" environment variable set.

```
docker run -it -e "IotHubConnectionString=xxx" -e DeviceList="sim000001,sim000002" -e Template="{ \"deviceId\": \"$.DeviceId\", \"temp\": \"$.Temp\" }" -e Variables="[ { \"name\": \"Temp\", \"random\": true, \"max\": 25, \"min\": 23 }, { \"name\": \"Counter\", \"min\": 100 } ]" iottelemetrysimulator/azureiot-telemetrysimulator:latest
```

## What to Check
Verify that the following are valid
* Verify that the telemetry sent by this example looks like this:

```
4/20/2020 2:32:43 PM> Device: [sim000001], Data:[{ "deviceId": "sim000001", "temp": "23" }]
```
