### PR TITLE
Accurate delay computation

### DIFF
--- a/src/IotTelemetrySimulator/SimulatedDevice.cs
+++ b/src/IotTelemetrySimulator/SimulatedDevice.cs
@@ -1,6 +1,7 @@
 ﻿namespace IotTelemetrySimulator
 {
     using System;
+    using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -8,6 +9,7 @@
     {
         private readonly ISender sender;
         private RunnerConfiguration config;
+        private IRandomizer random = new DefaultRandomizer();
 
         public string DeviceID { get; private set; }
 
@@ -30,10 +32,17 @@
                 await this.sender.OpenAsync();
                 stats.IncrementDeviceConnected();
 
-                for (var i = 0; !cancellationToken.IsCancellationRequested && (this.config.MessageCount <= 0 || i < this.config.MessageCount); i++)
+                // Delay first event by a random amount to avoid bursts
+                await Task.Delay(this.random.Next(this.config.Interval), cancellationToken);
+
+                var stopwatch = new Stopwatch();
+                stopwatch.Start();
+                for (var i = 0L; !cancellationToken.IsCancellationRequested && (this.config.MessageCount <= 0 || i < this.config.MessageCount); i++)
                 {
-                    await Task.Delay(this.config.Interval, cancellationToken);
                     await this.sender.SendMessageAsync(stats, cancellationToken);
+
+                    var millisecondsDelay = Math.Max(0, this.config.Interval * i - stopwatch.ElapsedMilliseconds);
+                    await Task.Delay((int)millisecondsDelay, cancellationToken);
                 }
 
                 stats.IncrementCompletedDevice();


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Avoid bursts by introducing a random delay for each device (between 0 and the interval between events) before sending the first event.
* Send events at accurate interval (currently, the time taken to send the event is not counted). This allows stable and accurate event rate

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```
