### PR TITLE
Allow providing PartitionKey for Event Hubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The amount of devices, their names and telemetry generated can be customized usi
 |FixPayloadSize|fix telemetry payload size (in bytes). Use this setting if the content of the message does not need to change (will be an array filled with zeros)|
 |PayloadDistribution|Allows the generation of payloads based on a distribution<br />Example: "fixSize(10, 12) template(25, default) fix(65, aaaaBBBBBCCC)" generates 10% a fix payload of 10 bytes, 25% a template generated payload and 65% of the time a fix payload from values aaaaBBBBBCCC|
 |Header|telemetry header template (see telemetry template)|
+|PartitionKey|optional [partition key](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-features#partitions) template for Event Hubs (see telemetry template)|
 |Variables|telemetry variables (see telemetry template)|
 
 ## Telemetry template

--- a/src/IotTelemetrySimulator.Automation/Configuration.cs
+++ b/src/IotTelemetrySimulator.Automation/Configuration.cs
@@ -48,6 +48,8 @@
 
         public string Header { get; set; }
 
+        public string PartitionKey { get; set; }
+
         public int DeviceCount { get; set; }
 
         public int MessageCount { get; set; }

--- a/src/IotTelemetrySimulator.Automation/IotTelemetrySimulatorAutomation.cs
+++ b/src/IotTelemetrySimulator.Automation/IotTelemetrySimulatorAutomation.cs
@@ -32,6 +32,7 @@
                 { "Variables", this.configuration.Variables },
                 { "DevicePrefix", this.configuration.DevicePrefix },
                 { "Header", this.configuration.Header },
+                { "PartitionKey", this.configuration.PartitionKey },
                 { "MessageCount", this.configuration.MessageCount.ToString() },
                 { "Interval", this.configuration.Interval.ToString() },
                 { "DeviceCount", this.devicesPerContainer.ToString() },

--- a/src/IotTelemetrySimulator.Automation/appsettings.json
+++ b/src/IotTelemetrySimulator.Automation/appsettings.json
@@ -26,6 +26,7 @@
   "Variables": "[{\"name\": \"PayloadString500b\", \"customLengthString\": 500}, {\"name\": \"PayloadString1kb\", \"customLengthString\": 1000}]",
   "DevicePrefix": "TestDevice",
   "Header": "",
+  "PartitionKey":  "",
 
   "DeviceCount": 10,
   "MessageCount": 120,

--- a/src/IotTelemetrySimulator/EventHubSender.cs
+++ b/src/IotTelemetrySimulator/EventHubSender.cs
@@ -17,7 +17,16 @@
 
         protected override async Task SendAsync(EventData msg, CancellationToken cancellationToken)
         {
-            await this.eventHubClient.SendAsync(msg);
+            string partitionKey = this.FillTelemetryTemplate(this.Config.PartitionKey);
+
+            if (string.IsNullOrWhiteSpace(partitionKey))
+            {
+                await this.eventHubClient.SendAsync(msg);
+            }
+            else
+            {
+                await this.eventHubClient.SendAsync(msg, partitionKey);
+            }
         }
 
         public override Task OpenAsync()

--- a/src/IotTelemetrySimulator/TelemetryTemplate.cs
+++ b/src/IotTelemetrySimulator/TelemetryTemplate.cs
@@ -7,15 +7,8 @@
 
     public class TelemetryTemplate
     {
-        public const string DefaultTemplate = "{\"deviceId\": \"$.DeviceId\", \"time\": \"$.Time\", \"counter\": $.Counter}";
-
         private readonly string template;
         private readonly DefaultObjectPool<StringBuilder> stringBuilderPool;
-
-        public TelemetryTemplate()
-            : this(DefaultTemplate)
-        {
-        }
 
         public TelemetryTemplate(string template)
         {

--- a/test/IotTelemetrySimulator.Test/RunnerConfigurationTest.cs
+++ b/test/IotTelemetrySimulator.Test/RunnerConfigurationTest.cs
@@ -76,7 +76,7 @@ namespace IotTelemetrySimulator.Test
             Assert.Single(target.PayloadGenerator.Payloads);
 
             var templatedPayload = Assert.IsType<TemplatedPayload>(target.PayloadGenerator.Payloads[0]);
-            Assert.Equal(TelemetryTemplate.DefaultTemplate, templatedPayload.Template.ToString());
+            Assert.Equal(RunnerConfiguration.DefaultTemplate, templatedPayload.Template.ToString());
             Assert.Equal(100, target.PayloadGenerator.Payloads[0].Distribution);
         }
 
@@ -104,7 +104,7 @@ namespace IotTelemetrySimulator.Test
 
             var templatedPayload = Assert.IsType<TemplatedPayload>(target.PayloadGenerator.Payloads[1]);
             Assert.Equal(25, templatedPayload.Distribution);
-            Assert.Equal(TelemetryTemplate.DefaultTemplate, templatedPayload.Template.ToString());
+            Assert.Equal(RunnerConfiguration.DefaultTemplate, templatedPayload.Template.ToString());
 
             var fixPayload10 = Assert.IsType<FixPayload>(target.PayloadGenerator.Payloads[2]);
             Assert.Equal(10, fixPayload10.Distribution);


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* When processing events downstream with a distributed engine, it is often more efficient to have related messages in the same partition. For example, if computing values over windows of events per device in Spark, having all the events for a given device in the same partition ensures they are received by a single compute node and ordered. On the other hand, the default round-robin behavior has advantages too, such as ensuring all partitions have equal load and that the system remains available even if a partition fails. Therefore, it is good to give the user control over the partition key.
* As part of refactoring, the DefaultTemplate constant was moved out of TelemetryTemplate for separation of concerns

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Deploy Event Hub with 4 partitions
* Run with
  * DeviceCount: `2`
  * EventHubConnectionString: `Endpoint=sb://MYNAMESPACE.servicebus.windows.net/;SharedAccessKeyName=Send;SharedAccessKey=xxx=;EntityPath=MYHUB`
  * PartitionKey: `$.DeviceId`
* observe that all 4 partitions are used
* Run again, now adding:
  * PartitionKey: `$.DeviceId`
* observe that only 2 partitions are used

E.g. using Azure Portal "Process Data" feature:
![image](https://user-images.githubusercontent.com/22099722/103617646-e8566c80-4f2e-11eb-93e2-2cd992d93c73.png)
