### PR TITLE
Make payload generation linearly complex

### DIFF
--- a/src/IotTelemetrySimulator/Constants.cs
+++ b/src/IotTelemetrySimulator/Constants.cs
@@ -3,6 +3,10 @@
     public static class Constants
     {
         public const string AppVersion = "1.0";
+
+        public const string TemplateConfigName = "Template";
+        public const string PayloadDistributionConfigName = "PayloadDistribution";
+
         public const string TimeValueName = "Time";
         public const string LocalTimeValueName = "LocalTime";
         public const string EpochValueName = "Epoch";
@@ -10,8 +14,10 @@
         public const string DeviceIdValueName = "DeviceId";
         public const string GuidValueName = "Guid";
         public const string MachineNameValueName = "MachineName";
-
-        public const string TemplateConfigName = "Template";
-        public const string PayloadDistributionConfigName = "PayloadDistribution";
+        public static readonly string[] AllSpecialValueNames =
+        {
+            TimeValueName, LocalTimeValueName, EpochValueName, TicksValueName,
+            DeviceIdValueName, GuidValueName, MachineNameValueName,
+        };
     }
 }

--- a/src/IotTelemetrySimulator/RunnerConfiguration.cs
+++ b/src/IotTelemetrySimulator/RunnerConfiguration.cs
@@ -145,7 +145,7 @@
                 });
             }
 
-            var futureVariableNames = config.Variables.NextValues(previous: null).Keys;
+            var futureVariableNames = config.Variables.VariableNames().ToList();
 
             config.PayloadGenerator = new PayloadGenerator(
                 LoadPayloads(configuration, config, logger, futureVariableNames),

--- a/src/IotTelemetrySimulator/TelemetryTemplate.cs
+++ b/src/IotTelemetrySimulator/TelemetryTemplate.cs
@@ -15,6 +15,11 @@
         // Internal representation of the template that allows fast variable substitution.
         private List<TemplateToken> templateTokens;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TelemetryTemplate"/> class.
+        /// <param name="variableNames">All possible variable names that will be substituted
+        /// in this template in the future.</param>
+        /// </summary>
         public TelemetryTemplate(string template, IEnumerable<string> variableNames)
         {
             if (string.IsNullOrWhiteSpace(template))
@@ -59,15 +64,15 @@
         /// will be represented as a list of functions:
         /// [
         ///     (vars) => "Hello, ",
-        ///     (vars) => vars["name"],
+        ///     (vars) => vars.Contains("name") ? vars["name"].ToString() : "$.name",
         ///     (vars) => "! I like ",
-        ///     (vars) => "vars["var1"]",
+        ///     (vars) => vars.Contains("var1") ? vars["var1"].ToString() : "$.var1",
         ///     (vars) => ", ",
-        ///     (vars) => "vars["var11"]",
+        ///     (vars) => vars.Contains("var11") ? vars["var11"].ToString() : "$.var11",
         ///     (vars) => " and ",
-        ///     (vars) => "vars["var12"]",
+        ///     (vars) => vars.Contains("var12") ? vars["var12"].ToString() : "$.var12",
         ///     (vars) => ", ",
-        ///     (vars) => "vars["name"]",
+        ///     (vars) => vars.Contains("name") ? vars["name"].ToString() : "$.name",
         ///     (vars) => ".",
         /// ].
         /// </summary>
@@ -84,7 +89,11 @@
             // spoil all instances of "$.Var12".
             foreach (var varName in variableNames.OrderByDescending(s => s.Length))
             {
-                string Substitute(Dictionary<string, object> variables) => variables[varName].ToString();
+                string Substitute(Dictionary<string, object> variables)
+                {
+                    variables.TryGetValue(varName, out var result);
+                    return result == null ? "$." + varName : result.ToString();
+                }
 
                 // In all template substrings, replace all occurrences of $.varName
                 // with the corresponding TemplateToken.

--- a/src/IotTelemetrySimulator/TelemetryValues.cs
+++ b/src/IotTelemetrySimulator/TelemetryValues.cs
@@ -77,6 +77,14 @@
             return next;
         }
 
+        /// <summary>
+        /// All possible variable names this object can produce.
+        /// </summary>
+        public IEnumerable<string> VariableNames()
+        {
+            return this.Variables.Select(v => v.Name).Concat(Constants.AllSpecialValueNames);
+        }
+
         public string CreateRandomString(int length)
         {
             const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";

--- a/stylecop.props
+++ b/stylecop.props
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
   </ItemGroup>
 </Project>

--- a/test/IotTelemetrySimulator.Test/TemplateVariableSubstitutionTest.cs
+++ b/test/IotTelemetrySimulator.Test/TemplateVariableSubstitutionTest.cs
@@ -1,5 +1,6 @@
 ﻿namespace IotTelemetrySimulator.Test
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using Xunit;
@@ -8,15 +9,54 @@
     {
         private class CustomClass
         {
+            private readonly string message;
+
+            public CustomClass(string message)
+            {
+                this.message = message;
+            }
+
             public override string ToString()
             {
-                return "some_data";
+                return this.message;
             }
+        }
+
+        [Fact]
+        public void ShouldSubstituteSpecialVariables()
+        {
+            var variables = new TelemetryValues(new[]
+            {
+                new TelemetryVariable
+                {
+                    Min = 1,
+                    Name = "Counter",
+                    Step = 1,
+                },
+            });
+
+            var telemetryTemplate = new TelemetryTemplate(
+                $"$.Counter $.{Constants.TicksValueName} $.{Constants.GuidValueName}",
+                variables.VariableNames());
+
+            var generatedPayload = telemetryTemplate.Create(
+                variables.NextValues(previous: null));
+
+            var parts = generatedPayload.Split();
+
+            Assert.Equal(3, parts.Length);
+            Assert.Equal("1", parts[0]); // Counter must be 1
+            Assert.True(parts[1].All(char.IsDigit));  // Ticks must be an int
+            Assert.True(Guid.TryParse(parts[2], out _));  // Guid should be parseable
         }
 
         [Theory]
         [MemberData(nameof(GetTestData))]
-        public void ShouldSubstituteVariablesCorrectly(Dictionary<string, object> vars, string template, string expectedPayload)
+        public void ShouldSubstituteVariablesCorrectly(
+            Dictionary<string, object> previousValues,
+            Dictionary<string, object> vars,
+            string template,
+            string expectedPayload)
         {
             var variables = new TelemetryValues(
                 vars.Select(var => new TelemetryVariable
@@ -27,9 +67,10 @@
 
             var telemetryTemplate = new TelemetryTemplate(
                 template,
-                variables.NextValues(previous: null).Keys);
+                variables.VariableNames());
 
-            var generatedPayload = telemetryTemplate.Create(variables.NextValues(previous: null));
+            var generatedPayload = telemetryTemplate.Create(
+                variables.NextValues(previous: previousValues));
 
             Assert.Equal(expectedPayload, generatedPayload);
         }
@@ -37,44 +78,67 @@
         public static IEnumerable<object[]> GetTestData()
         {
             // Should convert variable values to string
-            var customObj = new CustomClass();
+            var customObj = new CustomClass("some_data");
             yield return new object[]
             {
+                null,
                 new Dictionary<string, object> { { "name", "World" }, { "var1", customObj }, { "var2", -0.5 }, { "var3", string.Empty } },
                 "Hello, $.name! I like $.var1, $.var2 and $.var3, $.name.",
-                "Hello, World! I like some_data, -0.5 and , World.",
+                $"Hello, World! I like some_data, -0.5 and , World.",
             };
 
             // Should ignore extra variables
             yield return new object[]
             {
+                null,
                 new Dictionary<string, object> { { "var1", 1 }, { "var2", 2 } },
                 "Only $.var1",
                 "Only 1",
             };
 
-            // Should ignore extra variables
+            // Should allow empty variables
             yield return new object[]
             {
-                new Dictionary<string, object> { { "var1", 1 }, { "var2", 2 } },
-                "Only $.var1",
-                "Only 1",
+                null,
+                new Dictionary<string, object>(),
+                "$.something",
+                "$.something",
             };
 
             // Should ignore non-existent variables in the template
             yield return new object[]
             {
+                null,
                 new Dictionary<string, object> { { "var1", 1 } },
                 "$.var1 $.var",
                 "1 $.var",
             };
 
+            // ..even with the special name
+            yield return new object[]
+            {
+                null,
+                new Dictionary<string, object> { { "var1", 1 } },
+                $"$.{Constants.DeviceIdValueName} $.var1 $.var",
+                $"$.{Constants.DeviceIdValueName} 1 $.var",
+            };
+
             // Should substitute longer names first
             yield return new object[]
             {
+                null,
                 new Dictionary<string, object> { { "var1", 1 }, { "var", 2 }, { "var11", 3 } },
                 "$.var1$.var11, $.var $.var$.var1$.var11!",
                 "13, 2 213!",
+            };
+
+            // Should substitute DeviceID if it's in the previous values
+            yield return new object[]
+            {
+                new Dictionary<string, object> { { Constants.DeviceIdValueName, "dummy" } },
+                new Dictionary<string, object> { { "var1", 1 } },
+                $"$.{Constants.DeviceIdValueName} $.var1!",
+                "dummy 1!",
             };
         }
     }

--- a/test/IotTelemetrySimulator.Test/TemplateVariableSubstitutionTest.cs
+++ b/test/IotTelemetrySimulator.Test/TemplateVariableSubstitutionTest.cs
@@ -1,0 +1,81 @@
+﻿namespace IotTelemetrySimulator.Test
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Xunit;
+
+    public class TemplateVariableSubstitutionTest
+    {
+        private class CustomClass
+        {
+            public override string ToString()
+            {
+                return "some_data";
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestData))]
+        public void ShouldSubstituteVariablesCorrectly(Dictionary<string, object> vars, string template, string expectedPayload)
+        {
+            var variables = new TelemetryValues(
+                vars.Select(var => new TelemetryVariable
+                {
+                    Name = var.Key,
+                    Values = new[] { var.Value },
+                }).ToArray());
+
+            var telemetryTemplate = new TelemetryTemplate(
+                template,
+                variables.NextValues(previous: null).Keys);
+
+            var generatedPayload = telemetryTemplate.Create(variables.NextValues(previous: null));
+
+            Assert.Equal(expectedPayload, generatedPayload);
+        }
+
+        public static IEnumerable<object[]> GetTestData()
+        {
+            // Should convert variable values to string
+            var customObj = new CustomClass();
+            yield return new object[]
+            {
+                new Dictionary<string, object> { { "name", "World" }, { "var1", customObj }, { "var2", -0.5 }, { "var3", string.Empty } },
+                "Hello, $.name! I like $.var1, $.var2 and $.var3, $.name.",
+                "Hello, World! I like some_data, -0.5 and , World.",
+            };
+
+            // Should ignore extra variables
+            yield return new object[]
+            {
+                new Dictionary<string, object> { { "var1", 1 }, { "var2", 2 } },
+                "Only $.var1",
+                "Only 1",
+            };
+
+            // Should ignore extra variables
+            yield return new object[]
+            {
+                new Dictionary<string, object> { { "var1", 1 }, { "var2", 2 } },
+                "Only $.var1",
+                "Only 1",
+            };
+
+            // Should ignore non-existent variables in the template
+            yield return new object[]
+            {
+                new Dictionary<string, object> { { "var1", 1 } },
+                "$.var1 $.var",
+                "1 $.var",
+            };
+
+            // Should substitute longer names first
+            yield return new object[]
+            {
+                new Dictionary<string, object> { { "var1", 1 }, { "var", 2 }, { "var11", 3 } },
+                "$.var1$.var11, $.var $.var$.var1$.var11!",
+                "13, 2 213!",
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Better review commit-by-commit

Continuation of #15.

The previous PR had a bug - `$.DeviceId` wasn't replaced in the template. We reverted it.

This PR has 2 commits:
1. The copy of #15 (revert of the revert);
2. The fix and more tests.