### PR TITLE
PR - Build with MSBuild 17.0, Visual Studio 2022.

### DIFF
--- a/src/IotSimulatorDeviceProvisioning/IotSimulatorDeviceProvisioning.csproj
+++ b/src/IotSimulatorDeviceProvisioning/IotSimulatorDeviceProvisioning.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.35.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.11.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Update="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/IotTelemetrySimulator.Automation.Console/IotTelemetrySimulator.Automation.Console.csproj
+++ b/src/IotTelemetrySimulator.Automation.Console/IotTelemetrySimulator.Automation.Console.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Update="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/IotTelemetrySimulator.Automation/IotTelemetrySimulator.Automation.csproj
+++ b/src/IotTelemetrySimulator.Automation/IotTelemetrySimulator.Automation.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Update="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/IotTelemetrySimulator/IotTelemetrySimulator.csproj
+++ b/src/IotTelemetrySimulator/IotTelemetrySimulator.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.9" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.11.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Update="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/IotTelemetrySimulator.Test/IotTelemetrySimulator.Test.csproj
+++ b/test/IotTelemetrySimulator.Test/IotTelemetrySimulator.Test.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Update="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Msbuild error NU1504, Duplicate 'PackageReference' items found for StyleCop.Analyzers.

## Purpose
To have a successful build with MsBuild 17.0 , Visual Studio 2022

## Does this introduce a breaking change?

[ ] Yes
[x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:


## How to Test
```
git clone https://github.com/MitaWinata/nu1504_build_error
cd nu1504_build_error
git checkout master
msbuild /restore
msbuild IotTelemetrySimulator.sln
```

## What to Check
Verify that the solution can be built.

## Other Information
https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1504