### PR TITLE
Allow Complex JSON as Template input

### DIFF
--- a/test/IotTelemetrySimulator.Test/IotTelemetrySimulator.Test.csproj
+++ b/test/IotTelemetrySimulator.Test/IotTelemetrySimulator.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
@@ -32,6 +32,9 @@
     <AdditionalFiles Include="../../stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="test_files\test9-config-array-template.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="test_files\test5-config-payloads-as-json.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/test/IotTelemetrySimulator.Test/RunnerConfigurationTest.cs
+++ b/test/IotTelemetrySimulator.Test/RunnerConfigurationTest.cs
@@ -296,5 +296,21 @@ namespace IotTelemetrySimulator.Test
 
             Assert.Throws<ConfigurationErrorsException>(() => RunnerConfiguration.Load(configuration, NullLogger.Instance));
         }
+
+        [Fact]
+        public void When_Payload_Array_Template_Loads_Correctly()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile("./test_files/test9-config-array-template.json", false, false)
+                .Build();
+
+            var target = RunnerConfiguration.Load(configuration, NullLogger.Instance);
+            var templatedPayload = Assert.IsType<TemplatedPayload>(target.PayloadGenerator.Payloads[0]);
+            Assert.Equal(1, templatedPayload.Variables.Variables.Count);
+            Assert.True(templatedPayload.Variables.Variables[0].Sequence);
+            Assert.Equal("device0001", templatedPayload.DeviceId);
+            Assert.Equal(new[] { "Counter" }, templatedPayload.Variables.Variables[0].GetReferenceVariableNames());
+            Assert.Equal("[{\"value1\":{\"value2\":\"$.Value\"}}]", templatedPayload.Template.ToString());
+        }
     }
 }

--- a/test/IotTelemetrySimulator.Test/test_files/test9-config-array-template.json
+++ b/test/IotTelemetrySimulator.Test/test_files/test9-config-array-template.json
@@ -1,0 +1,16 @@
+{
+  "Variables": [
+    {
+      "name": "Value",
+      "sequence": true,
+      "values": [ "$.Counter", "true" ]
+    }
+  ],
+  "Payloads": [
+    {
+      "type": "template",
+      "deviceId": "device0001",
+      "template": [{"value1": {"value2": "$.Value" } }]
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Previously nested and array JSON was converted to flat dictionary if it were not provided as a string to telemetry. This allows to store different and complex payloads much more nicely.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone git@github.com:Sefriol/Iot-Telemetry-Simulator.git
cd Iot-Telemetry-Simulator
git checkout feature/json-template
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->

Run the unit tests.

## What to Check
Verify that all tests pass

## Other Information

I had only Net6.0 and 7.0 on my computer and project build initially complained about multiple StyleCop configurations, so I am uncertain if everything is in order.